### PR TITLE
Shift chi2 by per-object best value before P(z) exponentiation

### DIFF
--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -990,12 +990,18 @@ function fit_streaming(param::Dict, templgrid::Array{Float32,3}, template_error_
                 chi2_col = @view chunk_chi2grid[:, j]
                 store_pz = chunk_pz_grid !== nothing
 
+                # Shift by per-object min chi2 so peak pz=1: keeps total above the
+                # Float32 reciprocal threshold and avoids NaN in normalized P(z) for
+                # poorly-fit objects. chi2best<0 means failed object → falls through
+                # to the total<=0 branch below regardless of shift.
+                chi2_min = chunk_chi2best[j] > 0 ? chunk_chi2best[j] : 0.0
+
                 @inbounds begin
-                    pz_col[1] = chi2_col[1] < 0 ? 0.0 : exp(-0.5 * Float64(chi2_col[1]))
+                    pz_col[1] = chi2_col[1] < 0 ? 0.0 : exp(-0.5 * (Float64(chi2_col[1]) - chi2_min))
                     cumtrapz_col[1] = 0.0
                     cpz_col[1] = pz_col[1]
                     for i in 2:nz
-                        pz_col[i] = chi2_col[i] < 0 ? 0.0 : exp(-0.5 * Float64(chi2_col[i]))
+                        pz_col[i] = chi2_col[i] < 0 ? 0.0 : exp(-0.5 * (Float64(chi2_col[i]) - chi2_min))
                         cumtrapz_col[i] = cumtrapz_col[i-1] + half_dz * (pz_col[i] + pz_col[i-1])
                         cpz_col[i] = cpz_col[i-1] + pz_col[i]
                     end

--- a/src/io.jl
+++ b/src/io.jl
@@ -821,9 +821,18 @@ function convert_hdf5_to_fits_python(hdf5_file::String, fits_file::String)
             zgrid = read(meta, "zgrid")
             chi2grid = read(h5f["pz/chi2grid"])  # (nz, nobj)
 
-            # Convert chi2 to P(z) and normalize each column (object)
-            pz = exp.(-0.5 * chi2grid)
-            for col in 1:size(pz, 2)
+            # Convert chi2 to P(z) and normalize each column (object).
+            # Per-column shift by chi2best keeps exp() in a safe range; sentinel
+            # entries (chi2<0) must be zeroed explicitly — exp(-0.5*-1)=1.648
+            # would otherwise leak into the normalization.
+            nz_local, nobj_local = size(chi2grid)
+            pz = zeros(Float64, nz_local, nobj_local)
+            for col in 1:nobj_local
+                shift = chi2best[col] > 0 ? Float64(chi2best[col]) : 0.0
+                @inbounds for i in 1:nz_local
+                    c = Float64(chi2grid[i, col])
+                    pz[i, col] = c < 0 ? 0.0 : exp(-0.5 * (c - shift))
+                end
                 norm = trapz(zgrid, @view pz[:, col])
                 if norm > 0
                     pz[:, col] ./= norm

--- a/src/templates/template_directory.toml
+++ b/src/templates/template_directory.toml
@@ -72,7 +72,7 @@
         'sfhz/corr_sfhz_13_bin0_av0.50.fits',
         'sfhz/corr_sfhz_13_bin0_av0.25.fits',
         'sfhz/corr_sfhz_13_bin0_av0.01.fits',
-        'Larson22/binc100z001age6.dat',
+        # 'Larson22/binc100z001age6.dat',
         'Larson22/binc100z001age6_cloudy.dat',
         'Larson22/binc100z001age65_cloudy.dat',
         'Larson22/binc100z001age65.dat',


### PR DESCRIPTION
## Summary
Normalized P(z) could become `NaN` for poorly-fit objects. When χ² was large across the *entire* redshift grid, `exp(-0.5*chi2)` underflowed to `0` at every bin, leaving a zero total that failed the Float32 reciprocal threshold used for normalization.

This shifts each object's column by its best χ² (`chi2best`) before exponentiating, so the peak is `exp(0)=1` and the total stays well above the underflow threshold. The shift cancels out in the normalized distribution, so P(z) values are unchanged for well-fit objects.

## Changes
- **`src/fitting.jl`** — `fit_streaming`: subtract per-object `chunk_chi2best` before `exp`. Objects with `chi2best<0` (failed) use a zero shift and fall through to the existing `total<=0` branch.
- **`src/io.jl`** — `convert_hdf5_to_fits_python`: same shift in the HDF5→FITS conversion path. Sentinel entries (`chi2<0`) are zeroed explicitly so `exp(-0.5*-1)=1.648` can't leak into the normalization.
- **`src/templates/template_directory.toml`** — drop the non-cloudy `Larson22/binc100z001age6` template from the `sfhz_13` set.

## Notes
Both code paths apply the identical numerical fix so the streaming output and the Python-conversion output stay consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)