### PR TITLE
Fix P(z) underflow/overflow for high-chi² fits

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,6 +40,7 @@ julia = "1.12"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Trapz = "592b5752-818d-11e9-1e9a-2b8ca4a44cd1"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Trapz"]

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -210,8 +210,9 @@ function fit_single_object(j::Int, fnu_j::AbstractVector{Float64}, efnu_j::Abstr
                 continue
             end
             
-            # Store chi2 for P(z) calculation
-            chi2_row[i] = chi2_j
+            # Store chi2 for P(z) calculation, clamped so the Float32
+            # conversion can't overflow to Inf for pathological fits
+            chi2_row[i] = Float32(min(chi2_j, Float64(floatmax(Float32))))
             
             # Update best fit if this is better
             if chi2_j < best_chi2
@@ -1003,12 +1004,13 @@ function fit_streaming(param::Dict, templgrid::Array{Float32,3}, template_error_
                 end
                 isfinite(chi2_min) || (chi2_min = 0.0)
 
+                # `c >= 0` (not `c < 0`) so NaN chi2 also falls to P(z) = 0
                 @inbounds begin
-                    pz_col[1] = chi2_col[1] < 0 ? 0.0 : exp(-0.5 * (Float64(chi2_col[1]) - chi2_min))
+                    pz_col[1] = chi2_col[1] >= 0 ? exp(-0.5 * (Float64(chi2_col[1]) - chi2_min)) : 0.0
                     cumtrapz_col[1] = 0.0
                     cpz_col[1] = pz_col[1]
                     for i in 2:nz
-                        pz_col[i] = chi2_col[i] < 0 ? 0.0 : exp(-0.5 * (Float64(chi2_col[i]) - chi2_min))
+                        pz_col[i] = chi2_col[i] >= 0 ? exp(-0.5 * (Float64(chi2_col[i]) - chi2_min)) : 0.0
                         cumtrapz_col[i] = cumtrapz_col[i-1] + half_dz * (pz_col[i] + pz_col[i-1])
                         cpz_col[i] = cpz_col[i-1] + pz_col[i]
                     end
@@ -1112,10 +1114,10 @@ function fit_streaming(param::Dict, templgrid::Array{Float32,3}, template_error_
                     lowz_trapz_total = 0.0
                     if isfinite(lowz_chi2_min)
                         @inbounds begin
-                            pz_col[1] = chi2_col[1] < 0 ? 0.0 : exp(-0.5 * (Float64(chi2_col[1]) - lowz_chi2_min))
+                            pz_col[1] = chi2_col[1] >= 0 ? exp(-0.5 * (Float64(chi2_col[1]) - lowz_chi2_min)) : 0.0
                             cpz_col[1] = pz_col[1]
                             for i in 2:lowz_nz
-                                pz_col[i] = chi2_col[i] < 0 ? 0.0 : exp(-0.5 * (Float64(chi2_col[i]) - lowz_chi2_min))
+                                pz_col[i] = chi2_col[i] >= 0 ? exp(-0.5 * (Float64(chi2_col[i]) - lowz_chi2_min)) : 0.0
                                 lowz_trapz_total += half_dz * (pz_col[i] + pz_col[i-1])
                                 cpz_col[i] = cpz_col[i-1] + pz_col[i]
                             end

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -990,12 +990,25 @@ function fit_streaming(param::Dict, templgrid::Array{Float32,3}, template_error_
                 chi2_col = @view chunk_chi2grid[:, j]
                 store_pz = chunk_pz_grid !== nothing
 
+                # Shift chi2 by its minimum valid value before exponentiating.
+                # The shift cancels in every normalized quantity, but without it
+                # exp(-chi2/2) underflows and 1/total overflows Float32 once
+                # min(chi2) ≳ 180, turning the stored P(z) into Inf/NaN.
+                chi2_min = Inf
+                @inbounds for i in 1:nz
+                    c = chi2_col[i]
+                    if c >= 0 && c < chi2_min
+                        chi2_min = Float64(c)
+                    end
+                end
+                isfinite(chi2_min) || (chi2_min = 0.0)
+
                 @inbounds begin
-                    pz_col[1] = chi2_col[1] < 0 ? 0.0 : exp(-0.5 * Float64(chi2_col[1]))
+                    pz_col[1] = chi2_col[1] < 0 ? 0.0 : exp(-0.5 * (Float64(chi2_col[1]) - chi2_min))
                     cumtrapz_col[1] = 0.0
                     cpz_col[1] = pz_col[1]
                     for i in 2:nz
-                        pz_col[i] = chi2_col[i] < 0 ? 0.0 : exp(-0.5 * Float64(chi2_col[i]))
+                        pz_col[i] = chi2_col[i] < 0 ? 0.0 : exp(-0.5 * (Float64(chi2_col[i]) - chi2_min))
                         cumtrapz_col[i] = cumtrapz_col[i-1] + half_dz * (pz_col[i] + pz_col[i-1])
                         cpz_col[i] = cpz_col[i-1] + pz_col[i]
                     end
@@ -1018,11 +1031,12 @@ function fit_streaming(param::Dict, templgrid::Array{Float32,3}, template_error_
                     continue
                 end
 
-                # Store normalized P(z) for HDF5 output
+                # Store normalized P(z) for HDF5 output (normalize in Float64,
+                # convert only the final value to Float32)
                 if store_pz
-                    inv_total = Float32(1.0 / total)
+                    inv_total = 1.0 / total
                     @inbounds for i in 1:nz
-                        chunk_pz_grid[i, j] = Float32(pz_col[i]) * inv_total
+                        chunk_pz_grid[i, j] = Float32(pz_col[i] * inv_total)
                     end
                 end
 
@@ -1084,16 +1098,27 @@ function fit_streaming(param::Dict, templgrid::Array{Float32,3}, template_error_
                         chunk_delta_chi2[j] = chunk_chi2best_lowz[j] - chunk_chi2best[j]
                     end
 
-                    # Lowz P(z) and CDF — reuse pz_col values already computed above
+                    # Lowz P(z) and CDF — recompute with a lowz-specific chi2
+                    # shift: the global best fit may lie outside the lowz range,
+                    # leaving the globally-shifted pz values underflowed here
                     lowz_nz = iz_lowz_max
-                    lowz_total = 0.0
+                    lowz_chi2_min = Inf
                     @inbounds for i in 1:lowz_nz
-                        lowz_total += pz_col[i]
+                        c = chi2_col[i]
+                        if c >= 0 && c < lowz_chi2_min
+                            lowz_chi2_min = Float64(c)
+                        end
                     end
-                    if lowz_total > 0
-                        cpz_col[1] = pz_col[1]
-                        @inbounds for i in 2:lowz_nz
-                            cpz_col[i] = cpz_col[i-1] + pz_col[i]
+                    lowz_trapz_total = 0.0
+                    if isfinite(lowz_chi2_min)
+                        @inbounds begin
+                            pz_col[1] = chi2_col[1] < 0 ? 0.0 : exp(-0.5 * (Float64(chi2_col[1]) - lowz_chi2_min))
+                            cpz_col[1] = pz_col[1]
+                            for i in 2:lowz_nz
+                                pz_col[i] = chi2_col[i] < 0 ? 0.0 : exp(-0.5 * (Float64(chi2_col[i]) - lowz_chi2_min))
+                                lowz_trapz_total += half_dz * (pz_col[i] + pz_col[i-1])
+                                cpz_col[i] = cpz_col[i-1] + pz_col[i]
+                            end
                         end
                         lowz_cpz_norm = cpz_col[lowz_nz]
                         if lowz_cpz_norm > 0
@@ -1116,13 +1141,10 @@ function fit_streaming(param::Dict, templgrid::Array{Float32,3}, template_error_
                     end
 
                     # Lowz P(z) grid (normalized over lowz range only)
-                    if chunk_pz_grid_lowz !== nothing
-                        lowz_trapz_total = cumtrapz_col[iz_lowz_max]
-                        if lowz_trapz_total > 0
-                            inv_lowz_trapz = Float32(1.0 / lowz_trapz_total)
-                            @inbounds for i in 1:lowz_nz
-                                chunk_pz_grid_lowz[i, j] = Float32(pz_col[i]) * inv_lowz_trapz
-                            end
+                    if chunk_pz_grid_lowz !== nothing && lowz_trapz_total > 0
+                        inv_lowz_trapz = 1.0 / lowz_trapz_total
+                        @inbounds for i in 1:lowz_nz
+                            chunk_pz_grid_lowz[i, j] = Float32(pz_col[i] * inv_lowz_trapz)
                         end
                     end
 

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -22,6 +22,15 @@ const FLUX_ZP = Dict(
 
 const RF_MAG_NAMES = ["M_UV", "M_U", "M_V", "M_J"]
 
+# Sentinel chi2 values marking unfittable redshift bins: CHI2_POOR_FIT flags an
+# all-zero-coefficient fit, CHI2_ZFIX_FILLER fills the non-fitted bins in
+# z_spec mode. Bins at or above CHI2_PZ_MAX are excluded from P(z) like the
+# negative sentinel — before the chi2-min shift they always underflowed to
+# zero, and shifting relative to a sentinel would fabricate a flat P(z).
+const CHI2_POOR_FIT = Float32(1e10)
+const CHI2_ZFIX_FILLER = Float32(1e18)
+const CHI2_PZ_MAX = 1.0e10
+
 """
     luminosity_distance_Mpc(z, H0, Om)
 
@@ -101,7 +110,7 @@ function fit_single_object(j::Int, fnu_j::AbstractVector{Float64}, efnu_j::Abstr
 
         # Handle fixed redshift (z_spec mode)
         if z_fix_idx > 0
-            fill!(chi2_row, Float32(1e18))
+            fill!(chi2_row, CHI2_ZFIX_FILLER)
             z_range = z_fix_idx:z_fix_idx
         else
             z_range = 1:nz
@@ -185,7 +194,7 @@ function fit_single_object(j::Int, fnu_j::AbstractVector{Float64}, efnu_j::Abstr
             
             if all(x -> x ≈ 0.0, result)
                 #@warn "⚠️ All-zero coefficients detected for object $j at z=$(zgrid[i]). Poor template fit."
-                chi2_row[i] = 1e10  # High chi2 to mark as poor fit
+                chi2_row[i] = CHI2_POOR_FIT  # High chi2 to mark as poor fit
                 continue
             end
             
@@ -995,22 +1004,23 @@ function fit_streaming(param::Dict, templgrid::Array{Float32,3}, template_error_
                 # The shift cancels in every normalized quantity, but without it
                 # exp(-chi2/2) underflows and 1/total overflows Float32 once
                 # min(chi2) ≳ 180, turning the stored P(z) into Inf/NaN.
+                # Valid means 0 <= chi2 < CHI2_PZ_MAX: the chained comparison
+                # rejects the negative and high-chi2 sentinels and NaN alike.
                 chi2_min = Inf
                 @inbounds for i in 1:nz
                     c = chi2_col[i]
-                    if c >= 0 && c < chi2_min
+                    if 0 <= c < CHI2_PZ_MAX && c < chi2_min
                         chi2_min = Float64(c)
                     end
                 end
                 isfinite(chi2_min) || (chi2_min = 0.0)
 
-                # `c >= 0` (not `c < 0`) so NaN chi2 also falls to P(z) = 0
                 @inbounds begin
-                    pz_col[1] = chi2_col[1] >= 0 ? exp(-0.5 * (Float64(chi2_col[1]) - chi2_min)) : 0.0
+                    pz_col[1] = 0 <= chi2_col[1] < CHI2_PZ_MAX ? exp(-0.5 * (Float64(chi2_col[1]) - chi2_min)) : 0.0
                     cumtrapz_col[1] = 0.0
                     cpz_col[1] = pz_col[1]
                     for i in 2:nz
-                        pz_col[i] = chi2_col[i] >= 0 ? exp(-0.5 * (Float64(chi2_col[i]) - chi2_min)) : 0.0
+                        pz_col[i] = 0 <= chi2_col[i] < CHI2_PZ_MAX ? exp(-0.5 * (Float64(chi2_col[i]) - chi2_min)) : 0.0
                         cumtrapz_col[i] = cumtrapz_col[i-1] + half_dz * (pz_col[i] + pz_col[i-1])
                         cpz_col[i] = cpz_col[i-1] + pz_col[i]
                     end
@@ -1107,17 +1117,17 @@ function fit_streaming(param::Dict, templgrid::Array{Float32,3}, template_error_
                     lowz_chi2_min = Inf
                     @inbounds for i in 1:lowz_nz
                         c = chi2_col[i]
-                        if c >= 0 && c < lowz_chi2_min
+                        if 0 <= c < CHI2_PZ_MAX && c < lowz_chi2_min
                             lowz_chi2_min = Float64(c)
                         end
                     end
                     lowz_trapz_total = 0.0
                     if isfinite(lowz_chi2_min)
                         @inbounds begin
-                            pz_col[1] = chi2_col[1] >= 0 ? exp(-0.5 * (Float64(chi2_col[1]) - lowz_chi2_min)) : 0.0
+                            pz_col[1] = 0 <= chi2_col[1] < CHI2_PZ_MAX ? exp(-0.5 * (Float64(chi2_col[1]) - lowz_chi2_min)) : 0.0
                             cpz_col[1] = pz_col[1]
                             for i in 2:lowz_nz
-                                pz_col[i] = chi2_col[i] >= 0 ? exp(-0.5 * (Float64(chi2_col[i]) - lowz_chi2_min)) : 0.0
+                                pz_col[i] = 0 <= chi2_col[i] < CHI2_PZ_MAX ? exp(-0.5 * (Float64(chi2_col[i]) - lowz_chi2_min)) : 0.0
                                 lowz_trapz_total += half_dz * (pz_col[i] + pz_col[i-1])
                                 cpz_col[i] = cpz_col[i-1] + pz_col[i]
                             end

--- a/src/io.jl
+++ b/src/io.jl
@@ -492,6 +492,42 @@ function check_resume_file(filename::String)
 end
 
 """
+    chi2grid_to_pz(chi2grid, zgrid)
+
+Convert a (nz, nobj) chi² grid to trapz-normalized P(z). Each column is shifted
+by its minimum valid chi² before exponentiating — the shift cancels in the
+normalization, but keeps exp(-chi²/2) from underflowing for poor fits (high
+chi²), which would otherwise leave P(z) as zeros, Inf, or NaN. Negative chi²
+values are sentinels for invalid fits and yield P(z) = 0; a column with no
+valid chi² is left as all zeros.
+"""
+function chi2grid_to_pz(chi2grid::AbstractMatrix{<:Real}, zgrid::AbstractVector{Float64})
+    nz, nobj = size(chi2grid)
+    pz = zeros(Float64, nz, nobj)
+    for col in 1:nobj
+        chi2_min = Inf
+        @inbounds for i in 1:nz
+            c = chi2grid[i, col]
+            if c >= 0 && c < chi2_min
+                chi2_min = Float64(c)
+            end
+        end
+        isfinite(chi2_min) || continue
+        @inbounds for i in 1:nz
+            c = chi2grid[i, col]
+            pz[i, col] = c < 0 ? 0.0 : exp(-0.5 * (Float64(c) - chi2_min))
+        end
+        norm = trapz(zgrid, @view pz[:, col])
+        if norm > 0
+            @inbounds for i in 1:nz
+                pz[i, col] /= norm
+            end
+        end
+    end
+    return pz
+end
+
+"""
     write_chunk_results(file::HDF5.File, chunk_start, chunk_end, ...)
 
 Write a chunk of results to an open HDF5 file handle.
@@ -540,14 +576,7 @@ function write_chunk_results(file::HDF5.File, chunk_start::Int, chunk_end::Int,
             if pz_grid !== nothing
                 file["pz/pz"][:, chunk_start:chunk_end] = pz_grid
             elseif zgrid !== nothing
-                pz_chunk = exp.(-0.5f0 .* chi2grid)
-                for col in 1:size(pz_chunk, 2)
-                    norm = trapz(zgrid, @view pz_chunk[:, col])
-                    if norm > 0
-                        pz_chunk[:, col] ./= norm
-                    end
-                end
-                file["pz/pz"][:, chunk_start:chunk_end] = pz_chunk
+                file["pz/pz"][:, chunk_start:chunk_end] = Float32.(chi2grid_to_pz(chi2grid, zgrid))
             end
         end
     end
@@ -822,13 +851,7 @@ function convert_hdf5_to_fits_python(hdf5_file::String, fits_file::String)
             chi2grid = read(h5f["pz/chi2grid"])  # (nz, nobj)
 
             # Convert chi2 to P(z) and normalize each column (object)
-            pz = exp.(-0.5 * chi2grid)
-            for col in 1:size(pz, 2)
-                norm = trapz(zgrid, @view pz[:, col])
-                if norm > 0
-                    pz[:, col] ./= norm
-                end
-            end
+            pz = chi2grid_to_pz(chi2grid, zgrid)
 
             # Format for FITS: (nobj+1, nz) with zgrid as first row
             temp_pz = vcat(transpose(zgrid), transpose(pz))

--- a/src/io.jl
+++ b/src/io.jl
@@ -515,7 +515,8 @@ function chi2grid_to_pz(chi2grid::AbstractMatrix{<:Real}, zgrid::AbstractVector{
         isfinite(chi2_min) || continue
         @inbounds for i in 1:nz
             c = chi2grid[i, col]
-            pz[i, col] = c < 0 ? 0.0 : exp(-0.5 * (Float64(c) - chi2_min))
+            # `c >= 0` (not `c < 0`) so NaN chi2 also falls to P(z) = 0
+            pz[i, col] = c >= 0 ? exp(-0.5 * (Float64(c) - chi2_min)) : 0.0
         end
         norm = trapz(zgrid, @view pz[:, col])
         if norm > 0

--- a/src/io.jl
+++ b/src/io.jl
@@ -498,7 +498,8 @@ Convert a (nz, nobj) chi² grid to trapz-normalized P(z). Each column is shifted
 by its minimum valid chi² before exponentiating — the shift cancels in the
 normalization, but keeps exp(-chi²/2) from underflowing for poor fits (high
 chi²), which would otherwise leave P(z) as zeros, Inf, or NaN. Negative chi²
-values are sentinels for invalid fits and yield P(z) = 0; a column with no
+values and values at or above `CHI2_PZ_MAX` (the poor-fit and z_spec filler
+sentinels) are treated as invalid bins and yield P(z) = 0; a column with no
 valid chi² is left as all zeros.
 """
 function chi2grid_to_pz(chi2grid::AbstractMatrix{<:Real}, zgrid::AbstractVector{Float64})
@@ -508,15 +509,16 @@ function chi2grid_to_pz(chi2grid::AbstractMatrix{<:Real}, zgrid::AbstractVector{
         chi2_min = Inf
         @inbounds for i in 1:nz
             c = chi2grid[i, col]
-            if c >= 0 && c < chi2_min
+            if 0 <= c < CHI2_PZ_MAX && c < chi2_min
                 chi2_min = Float64(c)
             end
         end
         isfinite(chi2_min) || continue
         @inbounds for i in 1:nz
             c = chi2grid[i, col]
-            # `c >= 0` (not `c < 0`) so NaN chi2 also falls to P(z) = 0
-            pz[i, col] = c >= 0 ? exp(-0.5 * (Float64(c) - chi2_min)) : 0.0
+            # The chained comparison rejects the negative and high-chi2
+            # sentinels and NaN alike, all of which get P(z) = 0
+            pz[i, col] = 0 <= c < CHI2_PZ_MAX ? exp(-0.5 * (Float64(c) - chi2_min)) : 0.0
         end
         norm = trapz(zgrid, @view pz[:, col])
         if norm > 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,5 +110,16 @@ using Trapz
         # A column with no valid chi2 stays all-zero
         pz_none = Lazy.chi2grid_to_pz(fill(-1.0f0, nz, 2), zgrid)
         @test all(pz_none .== 0.0)
+
+        # Inf/NaN chi2 (e.g. from old work files) get P(z) = 0, not NaN
+        chi2_dirty = copy(chi2_good)
+        chi2_dirty[1] = Inf32
+        chi2_dirty[2] = NaN32
+        pz_dirty = Lazy.chi2grid_to_pz(reshape(chi2_dirty, nz, 1), zgrid)[:, 1]
+        @test pz_dirty[1] == 0.0 && pz_dirty[2] == 0.0
+        @test all(isfinite, pz_dirty)
+        @test trapz(zgrid, pz_dirty) ≈ 1.0 atol=1e-6
+        pz_allinf = Lazy.chi2grid_to_pz(fill(Inf32, nz, 1), zgrid)
+        @test all(pz_allinf .== 0.0)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Lazy
 using Test
+using Trapz
 
 @testset "Lazy.jl" begin
     @testset "Core functionality" begin
@@ -71,5 +72,43 @@ using Test
         @test zbest_fix == zgrid_test[3]
         @test chi2_row_fix[3] < 1e18
         @test all(chi2_row_fix[i] == Float32(1e18) for i in [1,2,4,5])
+    end
+
+    @testset "P(z) from high-chi2 grids (underflow regression)" begin
+        zgrid = collect(0.01:0.01:20.0)
+        nz = length(zgrid)
+
+        # Poor fit: min chi2 = 178 used to underflow exp(-chi2/2) and
+        # overflow Float32(1/total), producing all-NaN/Inf P(z)
+        chi2_poor = Float32.(178.0 .+ 2000.0 .* (zgrid .- 7.0) .^ 2 ./ (1 .+ zgrid))
+        pz = Lazy.chi2grid_to_pz(reshape(chi2_poor, nz, 1), zgrid)[:, 1]
+        @test all(isfinite, pz)
+        @test trapz(zgrid, pz) ≈ 1.0 atol=1e-6
+        @test argmax(pz) == argmin(chi2_poor)
+        @test all(isfinite, Float32.(pz))  # survives the Float32 output conversion
+
+        # Even chi2 in the thousands (underflows Float64 without the shift)
+        chi2_awful = Float32.(5000.0 .+ 100.0 .* (zgrid .- 10.0) .^ 2)
+        pz_awful = Lazy.chi2grid_to_pz(reshape(chi2_awful, nz, 1), zgrid)[:, 1]
+        @test all(isfinite, pz_awful)
+        @test trapz(zgrid, pz_awful) ≈ 1.0 atol=1e-6
+
+        # Shift-invariance: a good fit gives the same P(z) as the unshifted formula
+        chi2_good = Float32.(3.0 .+ 50.0 .* (zgrid .- 2.0) .^ 2)
+        pz_ref = exp.(-0.5 .* Float64.(chi2_good))
+        pz_ref ./= trapz(zgrid, pz_ref)
+        pz_good = Lazy.chi2grid_to_pz(reshape(chi2_good, nz, 1), zgrid)[:, 1]
+        @test pz_good ≈ pz_ref rtol=1e-6
+
+        # Negative chi2 is an invalid-fit sentinel: P(z) = 0 there
+        chi2_sent = copy(chi2_good)
+        chi2_sent[1:100] .= -1.0f0
+        pz_sent = Lazy.chi2grid_to_pz(reshape(chi2_sent, nz, 1), zgrid)[:, 1]
+        @test all(pz_sent[1:100] .== 0.0)
+        @test trapz(zgrid, pz_sent) ≈ 1.0 atol=1e-6
+
+        # A column with no valid chi2 stays all-zero
+        pz_none = Lazy.chi2grid_to_pz(fill(-1.0f0, nz, 2), zgrid)
+        @test all(pz_none .== 0.0)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,5 +121,25 @@ using Trapz
         @test trapz(zgrid, pz_dirty) ≈ 1.0 atol=1e-6
         pz_allinf = Lazy.chi2grid_to_pz(fill(Inf32, nz, 1), zgrid)
         @test all(pz_allinf .== 0.0)
+
+        # z_spec-mode filler (1e18) and poor-fit marker (1e10) are sentinels,
+        # not real chi2: they must not become the shift minimum. A rejected
+        # fixed-z fit (filler everywhere, -1 at the fixed bin) has no P(z).
+        chi2_zfix_rejected = fill(Lazy.CHI2_ZFIX_FILLER, nz)
+        chi2_zfix_rejected[500] = -1.0f0
+        pz_zfix = Lazy.chi2grid_to_pz(reshape(chi2_zfix_rejected, nz, 1), zgrid)[:, 1]
+        @test all(pz_zfix .== 0.0)
+
+        # A successful fixed-z fit yields a delta function at the fitted bin
+        chi2_zfix_ok = fill(Lazy.CHI2_ZFIX_FILLER, nz)
+        chi2_zfix_ok[500] = 250.0f0
+        pz_zfix_ok = Lazy.chi2grid_to_pz(reshape(chi2_zfix_ok, nz, 1), zgrid)[:, 1]
+        @test all(isfinite, pz_zfix_ok)
+        @test pz_zfix_ok[500] > 0
+        @test all(pz_zfix_ok[[1:499; 501:nz]] .== 0.0)
+
+        # All-poor-fit column (marker at every z) has no P(z)
+        pz_poor = Lazy.chi2grid_to_pz(fill(Lazy.CHI2_POOR_FIT, nz, 1), zgrid)
+        @test all(pz_poor .== 0.0)
     end
 end


### PR DESCRIPTION
## Summary
Fixes numerical instability in P(z) calculations when fitting poor-quality photometry with high minimum chi² values. Previously, `exp(-chi²/2)` would underflow to zero for chi² ≳ 180, causing P(z) normalization to fail with Inf/NaN values. The fix applies a per-column chi² shift before exponentiation—the shift cancels in normalized quantities but prevents underflow.

## Key Changes

- **Chi² clamping in `fit_single_object()`**: Store chi² values clamped to `Float32` max to prevent overflow during conversion
- **Chi² shifting in `fit_streaming()`**: 
  - Find minimum valid chi² per column before computing P(z)
  - Shift all chi² values by this minimum before exponentiation
  - Apply the same technique separately for low-z P(z) calculations
  - Normalize in Float64, convert only final P(z) values to Float32
- **New utility function `chi2grid_to_pz()`**: Extracted chi²→P(z) conversion logic into a reusable function in `io.jl` with proper handling of invalid fits (negative chi² sentinels, Inf/NaN values)
- **Updated chi² conversion in output**: Use the new `chi2grid_to_pz()` function in both HDF5 output and FITS conversion paths for consistency
- **Comprehensive test coverage**: Added regression tests covering poor fits (chi² ≈ 178), extreme fits (chi² ≈ 5000), shift-invariance, invalid-fit sentinels, and pathological Inf/NaN cases

## Implementation Details

- Negative chi² values are treated as invalid-fit sentinels and yield P(z) = 0
- Columns with no valid chi² remain all-zero
- The chi² shift is mathematically transparent: `exp(-chi²/2) / ∫exp(-chi²/2)dz = exp(-(chi²-min)/2) / ∫exp(-(chi²-min)/2)dz`
- Trapz integration is used for normalization to match the existing codebase
- Added `Trapz` to test dependencies for validation

https://claude.ai/code/session_01Qpf9RkcGuzNPaP9dBYrVF7